### PR TITLE
PHP 8.0 compatibilty by requiring  graze / dog-statsd 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php":">=7.2",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0",
         "symfony/yaml": "^3.4 || ^4.0 || ^5.0",
-        "graze/dog-statsd": "^0.4"
+        "graze/dog-statsd": "^0.4 || ^1.0"
     },
     "require-dev": {
         "ext-pdo_sqlite": "*",


### PR DESCRIPTION
- graze/dog-statsd 0.4 doesn't support PHP 8
- graze/dog-statsd 1.0 remove compatiblity for PHP 7.0 and 5.6 which is not an issue here
- I don't see [other possible issue](https://github.com/graze/dog-statsd/compare/0.4.3...1.0.0) by upgrading to 1.0

so allow PHP 8 compat by allowing 1.0 version of graze/dog-statsd.

Maybe even force 1.0 version ?