### PR TITLE
Add MockClient to simplify downstream testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
   - composer install --no-interaction
 
 script:
-  - php vendor/bin/phpunit --testsuite=functional
+  - php vendor/bin/phpunit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,9 @@
         <testsuite name="functional">
             <directory suffix="Test.php">tests/Functional</directory>
         </testsuite>
+        <testsuite name="unit">
+            <directory suffix="Test.php">tests/Unit</directory>
+        </testsuite>
     </testsuites>
     <php>
         <server name="KERNEL_DIR" value="tests/Functional/App"/>

--- a/src/Client/MockClient.php
+++ b/src/Client/MockClient.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Okvpn\Bundle\DatadogBundle\Client;
+
+final class MockClient implements DogStatsInterface
+{
+    private $data = [];
+
+    public function increment(string $metrics, int $delta = 1, float $sampleRate = 1.0, array $tags = [])
+    {
+        $this->data['increments'][] = [
+            'metric' => $metrics,
+            'delta' => $delta,
+            'sampleRate' => $sampleRate,
+            'tags' => $tags,
+        ];
+
+        return $this;
+    }
+
+    public function getIncrements(string $metric = null): array
+    {
+        return $this->get('increments', $metric);
+    }
+
+    public function decrement(string $metric, int $delta = 1, float $sampleRate = 1.0, array $tags = [])
+    {
+        $this->data['decrements'][] = [
+            'metric' => $metric,
+            'delta' => $delta,
+            'sampleRate' => $sampleRate,
+            'tags' => $tags,
+        ];
+
+        return $this;
+    }
+
+    public function getDecrements(string $metric = null): array
+    {
+        return $this->get('decrements', $metric);
+    }
+
+    public function timing(string $metric, float $time, array $tags = [])
+    {
+        $this->data['timings'][] = [
+            'metric' => $metric,
+            'time' => $time,
+            'tags' => $tags,
+        ];
+
+        return $this;
+    }
+
+    public function getTimings(string $metric = null): array
+    {
+        return $this->get('timings', $metric);
+    }
+
+    public function time(string $metric, callable $func, array $tags = [])
+    {
+        $timerStart = microtime(true);
+        $func();
+        $timerEnd = microtime(true);
+        $time = round(($timerEnd - $timerStart) * 1000, 4);
+
+        return $this->timing($metric, $time, $tags);
+    }
+
+    public function gauge(string $metric, int $value, array $tags = [])
+    {
+        $this->data['gauges'][] = [
+            'metric' => $metric,
+            'value' => $value,
+            'tags' => $tags,
+        ];
+
+        return $this;
+    }
+
+    public function getGauges(string $metric = null): array
+    {
+        return $this->get('gauges', $metric);
+    }
+
+    public function histogram(string $metric, float $value, float $sampleRate = 1.0, array $tags = [])
+    {
+        $this->data['histograms'][] = [
+            'metric' => $metric,
+            'value' => $value,
+            'sampleRate' => $sampleRate,
+            'tags' => $tags,
+        ];
+
+        return $this;
+    }
+
+    public function getHistograms(string $metric = null): array
+    {
+        return $this->get('histograms', $metric);
+    }
+
+    public function set(string $metric, int $value, array $tags = [])
+    {
+        $this->data['sets'][] = [
+            'metric' => $metric,
+            'value' => $value,
+            'tags' => $tags,
+        ];
+
+        return $this;
+    }
+
+    public function getSets(string $metric = null): array
+    {
+        return $this->get('sets', $metric);
+    }
+
+    public function event(string $title, string $text, array $metadata = [], array $tags = [])
+    {
+        $this->data['events'][] = [
+            'title' => $title,
+            'text' => $text,
+            'metadata' => $metadata,
+            'tags' => $tags,
+        ];
+
+        return $this;
+    }
+
+    public function getEvents(string $title = null): array
+    {
+        return $this->get('events', $title);
+    }
+
+    public function serviceCheck(string $name, int $status, array $metadata = [], array $tags = [])
+    {
+        $this->data['serviceChecks'][] = [
+            'name' => $name,
+            'status' => $status,
+            'metadata' => $metadata,
+            'tags' => $tags,
+        ];
+
+        return $this;
+    }
+
+    public function getServiceChecks(string $name = null): array
+    {
+        return $this->get('serviceChecks', $name);
+    }
+
+    public function getOptions(): array
+    {
+        return [];
+    }
+
+    public function getOption(string $name, $default = null)
+    {
+        return $default;
+    }
+
+    private function get(string $type, string $metric = null): array
+    {
+        if ($metric === null) {
+            return $this->data[$type];
+        }
+
+        if ($type === 'events') {
+            $key = 'title';
+        } elseif ($type === 'serviceChecks') {
+            $key = 'name';
+        } else {
+            $key = 'metric';
+        }
+
+        return array_filter($this->data[$type], static function (array $data) use ($key, $metric) {
+            return $data[$key] === $metric;
+        });
+    }
+}

--- a/tests/Unit/Client/MockClientTest.php
+++ b/tests/Unit/Client/MockClientTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Okvpn\Bundle\DatadogBundle\Tests\Unit\Client;
+
+use Okvpn\Bundle\DatadogBundle\Client\DogStatsInterface;
+use Okvpn\Bundle\DatadogBundle\Client\MockClient;
+use PHPUnit\Framework\TestCase;
+
+final class MockClientTest extends TestCase
+{
+    public function testIncrement(): void
+    {
+        $client = new MockClient();
+        $client->increment('foo');
+        $client->increment('foo', 2, 0.9, ['foo' => 'foo']);
+        $client->increment('bar');
+
+        $this->assertCount(3, $client->getIncrements());
+        $this->assertCount(2, $client->getIncrements('foo'));
+        $this->assertCount(1, $client->getIncrements('bar'));
+
+        $this->assertSame([
+            [
+                'metric' => 'foo',
+                'delta' => 1,
+                'sampleRate' => 1.0,
+                'tags' => [],
+            ],
+            [
+                'metric' => 'foo',
+                'delta' => 2,
+                'sampleRate' => 0.9,
+                'tags' => ['foo' => 'foo'],
+            ],
+            [
+                'metric' => 'bar',
+                'delta' => 1,
+                'sampleRate' => 1.0,
+                'tags' => [],
+            ],
+        ], $client->getIncrements());
+    }
+
+    public function testDecrement(): void
+    {
+        $client = new MockClient();
+        $client->decrement('foo');
+        $client->decrement('foo', 2, 0.9, ['foo' => 'foo']);
+        $client->decrement('bar');
+
+        $this->assertCount(3, $client->getDecrements());
+        $this->assertCount(2, $client->getDecrements('foo'));
+        $this->assertCount(1, $client->getDecrements('bar'));
+
+        $this->assertSame([
+            [
+                'metric' => 'foo',
+                'delta' => 1,
+                'sampleRate' => 1.0,
+                'tags' => [],
+            ],
+            [
+                'metric' => 'foo',
+                'delta' => 2,
+                'sampleRate' => 0.9,
+                'tags' => ['foo' => 'foo'],
+            ],
+            [
+                'metric' => 'bar',
+                'delta' => 1,
+                'sampleRate' => 1.0,
+                'tags' => [],
+            ],
+        ], $client->getDecrements());
+    }
+
+    public function testTimingAndTime(): void
+    {
+        $client = new MockClient();
+        $client->timing('foo', 100);
+        $client->timing('foo', 200, ['foo' => 'foo']);
+        $client->timing('bar', 300);
+        $client->time('baz', function () {
+            usleep(50);
+        });
+
+        $this->assertCount(4, $client->getTimings());
+        $this->assertCount(2, $client->getTimings('foo'));
+        $this->assertCount(1, $client->getTimings('bar'));
+        $this->assertCount(1, $client->getTimings('baz'));
+
+        $this->assertSame([
+            [
+                'metric' => 'foo',
+                'time' => 100.0,
+                'tags' => [],
+            ],
+            [
+                'metric' => 'foo',
+                'time' => 200.0,
+                'tags' => ['foo' => 'foo'],
+            ],
+        ], $client->getTimings('foo'));
+    }
+
+    public function testGauge(): void
+    {
+        $client = new MockClient();
+        $client->gauge('foo', 1);
+        $client->gauge('foo', 2, ['foo' => 'foo']);
+        $client->gauge('bar', 3);
+
+        $this->assertCount(3, $client->getGauges());
+        $this->assertCount(2, $client->getGauges('foo'));
+        $this->assertCount(1, $client->getGauges('bar'));
+
+        $this->assertSame([
+            [
+                'metric' => 'foo',
+                'value' => 1,
+                'tags' => [],
+            ],
+            [
+                'metric' => 'foo',
+                'value' => 2,
+                'tags' => ['foo' => 'foo'],
+            ],
+            [
+                'metric' => 'bar',
+                'value' => 3,
+                'tags' => [],
+            ],
+        ], $client->getGauges());
+    }
+
+    public function testHistogram(): void
+    {
+        $client = new MockClient();
+        $client->histogram('foo', 1.0);
+        $client->histogram('foo', 2.0, 0.5, ['foo' => 'foo']);
+        $client->histogram('bar', 3.0);
+
+        $this->assertCount(3, $client->getHistograms());
+        $this->assertCount(2, $client->getHistograms('foo'));
+        $this->assertCount(1, $client->getHistograms('bar'));
+
+        $this->assertSame([
+            [
+                'metric' => 'foo',
+                'value' => 1.0,
+                'sampleRate' => 1.0,
+                'tags' => [],
+            ],
+            [
+                'metric' => 'foo',
+                'value' => 2.0,
+                'sampleRate' => 0.5,
+                'tags' => ['foo' => 'foo'],
+            ],
+            [
+                'metric' => 'bar',
+                'value' => 3.0,
+                'sampleRate' => 1.0,
+                'tags' => [],
+            ],
+        ], $client->getHistograms());
+    }
+
+    public function testSet(): void
+    {
+        $client = new MockClient();
+        $client->set('foo', 1);
+        $client->set('foo', 2, ['foo' => 'foo']);
+        $client->set('bar', 3);
+
+        $this->assertCount(3, $client->getSets());
+        $this->assertCount(2, $client->getSets('foo'));
+        $this->assertCount(1, $client->getSets('bar'));
+
+        $this->assertSame([
+            [
+                'metric' => 'foo',
+                'value' => 1,
+                'tags' => [],
+            ],
+            [
+                'metric' => 'foo',
+                'value' => 2,
+                'tags' => ['foo' => 'foo'],
+            ],
+            [
+                'metric' => 'bar',
+                'value' => 3,
+                'tags' => [],
+            ],
+        ], $client->getSets());
+    }
+
+    public function testEvent(): void
+    {
+        $client = new MockClient();
+        $client->event('foo', 'Foo happened');
+        $client->event('foo', 'Foo happened', ['foo' => 1], ['foo' => 2]);
+        $client->event('bar', 'Bar happened');
+
+        $this->assertCount(3, $client->getEvents());
+        $this->assertCount(2, $client->getEvents('foo'));
+        $this->assertCount(1, $client->getEvents('bar'));
+
+        $this->assertSame([
+            [
+                'title' => 'foo',
+                'text' => 'Foo happened',
+                'metadata' => [],
+                'tags' => [],
+            ],
+            [
+                'title' => 'foo',
+                'text' => 'Foo happened',
+                'metadata' => ['foo' => 1],
+                'tags' => ['foo' => 2],
+            ],
+            [
+                'title' => 'bar',
+                'text' => 'Bar happened',
+                'metadata' => [],
+                'tags' => [],
+            ],
+        ], $client->getEvents());
+    }
+
+    public function testServiceCheck(): void
+    {
+        $client = new MockClient();
+        $client->serviceCheck('foo', DogStatsInterface::STATUS_OK);
+        $client->serviceCheck('foo', DogStatsInterface::STATUS_WARNING, ['foo' => 1], ['foo' => 2]);
+        $client->serviceCheck('bar', DogStatsInterface::STATUS_CRITICAL);
+
+        $this->assertCount(3, $client->getServiceChecks());
+        $this->assertCount(2, $client->getServiceChecks('foo'));
+        $this->assertCount(1, $client->getServiceChecks('bar'));
+
+        $this->assertSame([
+            [
+                'name' => 'foo',
+                'status' => DogStatsInterface::STATUS_OK,
+                'metadata' => [],
+                'tags' => [],
+            ],
+            [
+                'name' => 'foo',
+                'status' => DogStatsInterface::STATUS_WARNING,
+                'metadata' => ['foo' => 1],
+                'tags' => ['foo' => 2],
+            ],
+            [
+                'name' => 'bar',
+                'status' => DogStatsInterface::STATUS_CRITICAL,
+                'metadata' => [],
+                'tags' => [],
+            ],
+        ], $client->getServiceChecks());
+    }
+
+    public function testGetOptions(): void
+    {
+        $client = new MockClient();
+        $this->assertSame([], $client->getOptions());
+    }
+
+    public function testGetOption(): void
+    {
+        $client = new MockClient();
+        $this->assertSame(123, $client->getOption('foo', 123));
+    }
+}


### PR DESCRIPTION
 As a user of this library I would like an easier way to test that calls to a `DogStatsInterface` log the data I expect.  Currently, my only option is to create a mock/spy using the interface.  Doing this in PHPUnit requires me to provide the exact values for each parameter, but I may only care about testing a subset of those.

Providing a `MockClient` out-of-the box greatly simplifies this, as I can check the recorded stats in my tests and perform targeted assertions on just the field that I care about most.