### PR TITLE
Fix deprecation about internal class usage

### DIFF
--- a/src/DependencyInjection/OkvpnDatadogExtension.php
+++ b/src/DependencyInjection/OkvpnDatadogExtension.php
@@ -9,8 +9,8 @@ use Okvpn\Bundle\DatadogBundle\Client\DogStatsInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 class OkvpnDatadogExtension extends Extension


### PR DESCRIPTION
> The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, use Symfony\Component\DependencyInjection\Extension\Extension instead
