### PR TITLE
Fix implicit null parameter deprecations

### DIFF
--- a/src/Client/ClientWrapper.php
+++ b/src/Client/ClientWrapper.php
@@ -22,12 +22,9 @@ class ClientWrapper extends Client
      */
     protected $repeatCount = 0;
 
-    /**
-     * @var LoggerInterface
-     */
-    protected $logger;
+    protected ?LoggerInterface $logger = null;
 
-    public function __construct(LoggerInterface $logger = null, ?string $instanceId = null)
+    public function __construct(?LoggerInterface $logger = null, ?string $instanceId = null)
     {
         $this->logger = $logger;
         parent::__construct($instanceId);

--- a/src/Logging/DeduplicationDatadogLogger.php
+++ b/src/Logging/DeduplicationDatadogLogger.php
@@ -47,7 +47,7 @@ class DeduplicationDatadogLogger extends AbstractLogger
         LogLevel::DEBUG => DogStatsInterface::ALERT_INFO,
     ];
 
-    public function __construct(DogStatsInterface $statsd, ArtifactsStorageInterface $artifactStorage, ContextWatcherInterface $watcher, ContextDumperInterface $contextDumper, ExceptionHashService $exceptionHashService, string $deduplicationStore = null, int $deduplicationKeepTime = 86400 * 7)
+    public function __construct(DogStatsInterface $statsd, ArtifactsStorageInterface $artifactStorage, ContextWatcherInterface $watcher, ContextDumperInterface $contextDumper, ExceptionHashService $exceptionHashService, ?string $deduplicationStore = null, int $deduplicationKeepTime = 86400 * 7)
     {
         $this->statsd = $statsd;
         $this->artifactStorage = $artifactStorage;

--- a/src/Logging/Watcher/DefaultWatcher.php
+++ b/src/Logging/Watcher/DefaultWatcher.php
@@ -25,18 +25,12 @@ class DefaultWatcher implements ContextWatcherInterface
         $this->skipHeaders = $skipHttpHeaders;
     }
 
-    /**
-     * @param RequestStack $requestStack
-     */
-    public function setRequestStack(RequestStack $requestStack = null): void
+    public function setRequestStack(?RequestStack $requestStack = null): void
     {
         $this->requestStack = $requestStack;
     }
 
-    /**
-     * @param TokenStorageInterface $tokenStorage
-     */
-    public function setTokenStorage(TokenStorageInterface $tokenStorage = null): void
+    public function setTokenStorage(?TokenStorageInterface $tokenStorage = null): void
     {
         $this->tokenStorage = $tokenStorage;
     }


### PR DESCRIPTION
```
Deprecated: Okvpn\Bundle\DatadogBundle\Client\ClientWrapper::__construct(): Implicitly marking parameter $logger as nullable is deprecated, the explicit nullable type must be used instead
```

```
Okvpn\Bundle\DatadogBundle\Logging\DeduplicationDatadogLogger::__construct(): Implicitly marking parameter $deduplicationStore as nullable is deprecated, the explicit nullable type must be used instead
```

```
Okvpn\Bundle\DatadogBundle\Logging\Watcher\DefaultWatcher::setRequestStack(): Implicitly marking parameter $requestStack as nullable is deprecated, the explicit nullable type must be used instead
```

```
Okvpn\Bundle\DatadogBundle\Logging\Watcher\DefaultWatcher::setTokenStorage(): Implicitly marking parameter $tokenStorage as nullable is deprecated, the explicit nullable type must be used instead
```

typed properties are supported since PHP 7.4, and the `composer.json` indicates `"php":">=7.4"`, so there is no BC break with this